### PR TITLE
Automate pre-commit install with make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,14 @@ build:
 	rm -f bin/$(OPERATOR_NAME)
 	go build -mod vendor -v -o bin/$(OPERATOR_NAME) .
 
-golint:
+golint: .git/hooks/pre-commit
 	pre-commit run --all-files
 
 test:
 	go test -failfast -mod vendor ./*.go -v -covermode atomic -coverprofile=gotest-coverage.out $(GOTEST_REPORT_FORMAT) > gotest-report.out && cat gotest-report.out || (cat gotest-report.out; exit 1)
 	git diff --exit-code go.mod go.sum
+
+
+.git/hooks/pre-commit:
+	@pre-commit -V || (echo "pre-commit missing: https://pre-commit.com/" && exit 1)
+	pre-commit install


### PR DESCRIPTION
Use make to check if pre-commit hook is installed and if not use pre-commit to install it.