### PR TITLE
Update golangci-lint to support 1.20

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: vendor
 fail_fast: true
 repos:
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.50.1
+    rev: v1.51.1
     hooks:
       - id: golangci-lint
         args: [ --fix ]


### PR DESCRIPTION
Locally `make golint` will always crash with 1.20 when using older 1.50.1 golagnci-lint.