### PR TITLE
Support directories in watcher

### DIFF
--- a/v2/service/module/watcher/example_test.go
+++ b/v2/service/module/watcher/example_test.go
@@ -32,7 +32,7 @@ func ExampleNew() {
 	)
 
 	w := watcher.New(
-		watcher.WithFilename(tmpFile.Name()),
+		watcher.WithTarget(tmpFile.Name()),
 		watcher.WithFunc(func() error {
 			slog.Info("Hello from watcher")
 			return errors.New("watcher error")


### PR DESCRIPTION
Watching ConfigMap/Secret changes  in k8s require watching file creations in a directory rather than changes in a file itself