### PR TITLE
Add support for OTEL HTTP exporter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters:
     - dogsled
     - errorlint
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - gocognit
     - gocritic
     - gocyclo
@@ -42,7 +42,7 @@ issues:
       linters:
         - bodyclose
 linters-settings:
-  errcheckjson:
+  errchkjson:
     # report warning when checking error when not required
     check-error-free-encoding: true
     # encoding of struct with no exported fields
@@ -57,11 +57,13 @@ linters-settings:
   nolintlint:
     # Enable to ensure that nolint directives are all used. Default is true.
     allow-unused: false
-    # Disable to ensure that nolint directives don't have a leading space. Default is true.
-    allow-leading-space: false
     # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
     require-specific: true
   godot:
     # List of regexps for excluding particular comment lines from check.
     exclude:
       - "@Router"
+  gosec:
+    # disable G115 linter due to false positives and issues with the linter
+    excludes:
+      - G115

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -28,7 +28,9 @@ require (
 	github.com/urfave/cli/v2 v2.27.5
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.56.0
 	go.opentelemetry.io/otel v1.31.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.31.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0
 	go.opentelemetry.io/otel/sdk v1.31.0
 	golang.org/x/oauth2 v0.23.0
 	google.golang.org/grpc v1.67.1
@@ -348,8 +350,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.42.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v0.42.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
@@ -371,8 +371,8 @@ require (
 	golang.org/x/time v0.6.0 // indirect
 	golang.org/x/tools v0.24.0 // indirect
 	google.golang.org/genproto v0.0.0-20240930140551-af27646dc61f // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20241021214115-324edc3d5d38 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -928,8 +928,8 @@ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0 h1:K0XaT3DwHAcV4nKLzcQ
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.31.0/go.mod h1:B5Ki776z/MBnVha1Nzwp5arlzBbE3+1jk+pGmaP5HME=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.31.0 h1:FFeLy03iVTXP6ffeN2iXrxfGsZGCjVx0/4KlizjyBwU=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.31.0/go.mod h1:TMu73/k1CP8nBUpDLc71Wj/Kf7ZS9FK5b53VapRsP9o=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0 h1:digkEZCJWobwBqMwC0cwCq8/wkkRy/OowZg5OArWZrM=
-go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.21.0/go.mod h1:/OpE/y70qVkndM0TrxT4KBoN3RsFZP0QaofcfYrj76I=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0 h1:lUsI2TYsQw2r1IASwoROaCnjdj2cvC2+Jbxvk6nHnWU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.31.0/go.mod h1:2HpZxxQurfGxJlJDblybejHB6RX6pmExPNe517hREw4=
 go.opentelemetry.io/otel/metric v1.31.0 h1:FSErL0ATQAmYHUIzSezZibnyVlft1ybhy4ozRPcF2fE=
 go.opentelemetry.io/otel/metric v1.31.0/go.mod h1:C3dEloVbLuYoX41KpmAhOqNriGbA+qqH6PQ5E5mUfnY=
 go.opentelemetry.io/otel/sdk v1.31.0 h1:xLY3abVHYZ5HSfOg3l2E5LUj2Cwva5Y7yGxnSW9H5Gk=
@@ -1120,10 +1120,10 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto v0.0.0-20240930140551-af27646dc61f h1:mCJ6SGikSxVlt9scCayUl2dMq0msUgmBArqRY6umieI=
 google.golang.org/genproto v0.0.0-20240930140551-af27646dc61f/go.mod h1:xtVODtPkMQRUZ4kqOTgp6JrXQrPevvfCSdk4mJtHUbM=
-google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9 h1:T6rh4haD3GVYsgEfWExoCZA2o2FmbNyKpTuAxbEFPTg=
-google.golang.org/genproto/googleapis/api v0.0.0-20241007155032-5fefd90f89a9/go.mod h1:wp2WsuBYj6j8wUdo3ToZsdxxixbvQNAHqVJrTgi5E5M=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9 h1:QCqS/PdaHTSWGvupk2F/ehwHtGc0/GYkT+3GAcR1CCc=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20241007155032-5fefd90f89a9/go.mod h1:GX3210XPVPUjJbTUbvwI8f2IpZDMZuPJWDzDuebbviI=
+google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38 h1:2oV8dfuIkM1Ti7DwXc0BJfnwr9csz4TDXI9EmiI+Rbw=
+google.golang.org/genproto/googleapis/api v0.0.0-20241021214115-324edc3d5d38/go.mod h1:vuAjtvlwkDKF6L1GQ0SokiRLCGFfeBUXWr/aFFkHACc=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20241021214115-324edc3d5d38 h1:zciRKQ4kBpFgpfC5QQCVtnnNAcLIqweL7plyZRQHVpI=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20241021214115-324edc3d5d38/go.mod h1:GX3210XPVPUjJbTUbvwI8f2IpZDMZuPJWDzDuebbviI=
 google.golang.org/grpc v1.0.5/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.67.1 h1:zWnc1Vrcno+lHZCOofnIMvycFcc0QRGIzm9dhnDX68E=
 google.golang.org/grpc v1.67.1/go.mod h1:1gLDyUQU7CTLJI90u3nXZ9ekeghjeM7pTDZlqFNg2AA=

--- a/v2/golden/file_test.go
+++ b/v2/golden/file_test.go
@@ -54,7 +54,6 @@ func TestFileString(t *testing.T) {
 
 	t.Run("create", func(t *testing.T) {
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				mt := &tt.mt
 				got := string(file(mt, []byte(tt.data), true))
@@ -65,7 +64,6 @@ func TestFileString(t *testing.T) {
 
 	t.Run("read only", func(t *testing.T) {
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				mt := &tt.mt
 				got := FileString(mt, []byte(tt.data))
@@ -78,7 +76,6 @@ func TestFileString(t *testing.T) {
 
 	t.Run("override", func(t *testing.T) {
 		for _, tt := range tests {
-			tt := tt
 			tt.data += suffix
 			tt.expectedData += suffix
 			t.Run(tt.name, func(t *testing.T) {
@@ -91,7 +88,6 @@ func TestFileString(t *testing.T) {
 
 	t.Run("read only after override", func(t *testing.T) {
 		for _, tt := range tests {
-			tt := tt
 			tt.data += suffix
 			tt.expectedData += suffix
 			t.Run(tt.name, func(t *testing.T) {

--- a/v2/mfa/mfa.go
+++ b/v2/mfa/mfa.go
@@ -47,7 +47,7 @@ func getHOTPToken(secret string, interval int64) (string, error) {
 		return "", err
 	}
 	bs := make([]byte, 8)
-	binary.BigEndian.PutUint64(bs, uint64(interval)) //nolint:gosec // G115
+	binary.BigEndian.PutUint64(bs, uint64(interval))
 
 	// Signing the value using HMAC-SHA1 Algorithm
 	hash := hmac.New(sha1.New, key)

--- a/v2/service/module/ticker/ticker_test.go
+++ b/v2/service/module/ticker/ticker_test.go
@@ -71,7 +71,6 @@ func TestListenerInitErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.ticker.Init()
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/v2/service/module/tracerprovider/example_test.go
+++ b/v2/service/module/tracerprovider/example_test.go
@@ -12,9 +12,10 @@ import (
 func ExampleNew() {
 	tp := tracerprovider.New(
 		tracerprovider.WithSamplePercentage(42),
-		tracerprovider.WithCollector("localhost", 4317, insecure.NewCredentials()),
+		tracerprovider.WithGRPCExporter("localhost:4317", insecure.NewCredentials()),
 		tracerprovider.WithContext(context.Background()),
 		tracerprovider.WithServiceName("test"),
+		tracerprovider.WithEnvironment("development"),
 		tracerprovider.WithProcessor("processor"),
 	)
 	err := service.Run(service.Modules{tp})

--- a/v2/service/module/tracerprovider/tracerprovider.go
+++ b/v2/service/module/tracerprovider/tracerprovider.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
@@ -23,19 +26,31 @@ var (
 
 	ErrInvalidSamplePercentage = errors.New("invalid sample percentage")
 	ErrInvalidProcessor        = errors.New("invalid processor")
+	ErrInvalidToken            = errors.New("invalid token")
 )
+
+type ExporterHTTP struct {
+	endpoint string
+	token    string
+	insecure bool
+}
+
+type ExporterGRPC struct {
+	endpoint    string
+	credentials credentials.TransportCredentials
+}
 
 type TracerProvider struct {
 	provider         *trace.TracerProvider
 	ctx              context.Context //nolint:containedctx
 	serviceName      attribute.KeyValue
+	environment      attribute.KeyValue
 	resource         *resource.Resource
 	processorName    string
 	batchProcessor   trace.SpanProcessor
-	collectorHost    string
-	collectorPort    int
+	grpc             ExporterGRPC
+	http             ExporterHTTP
 	samplePercentage float64
-	credentials      credentials.TransportCredentials
 	stopped          chan struct{}
 	opts             []Opt
 }
@@ -57,6 +72,7 @@ func (tp *TracerProvider) Init() error {
 	res, err := resource.New(tp.ctx,
 		resource.WithAttributes(
 			tp.serviceName,
+			tp.environment,
 		),
 	)
 	if err != nil {
@@ -64,15 +80,13 @@ func (tp *TracerProvider) Init() error {
 	}
 	tp.resource = res
 
-	conn, err := grpc.NewClient(
-		fmt.Sprintf("%s:%d", tp.collectorHost, tp.collectorPort),
-		grpc.WithTransportCredentials(tp.credentials),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create gRPC connection to collector: %w", err)
+	var exporter *otlptrace.Exporter
+	// fallback to gRPC exporter if HTTP exporter is not configured
+	if tp.http.endpoint != "" {
+		exporter, err = tp.createHTTPExporter()
+	} else {
+		exporter, err = tp.createGRPCExporter()
 	}
-
-	exporter, err := otlptracegrpc.New(tp.ctx, otlptracegrpc.WithGRPCConn(conn))
 	if err != nil {
 		return fmt.Errorf("failed to create trace exporter: %w", err)
 	}
@@ -92,6 +106,42 @@ func (tp *TracerProvider) Init() error {
 	)
 
 	return nil
+}
+
+func (tp *TracerProvider) createHTTPExporter() (*otlptrace.Exporter, error) {
+	slog.Debug("using http exporter",
+		slog.String("endpoint", tp.http.endpoint),
+		slog.Bool("insecure", tp.http.insecure),
+	)
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(tp.http.endpoint),
+		otlptracehttp.WithCompression(otlptracehttp.GzipCompression),
+	}
+	if tp.http.insecure {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	if tp.http.token != "" {
+		opts = append(opts, otlptracehttp.WithHeaders(map[string]string{
+			"Authorization": tp.http.token,
+		}))
+	}
+	exporter, err := otlptracehttp.New(tp.ctx, opts...)
+	return exporter, err
+}
+
+func (tp *TracerProvider) createGRPCExporter() (*otlptrace.Exporter, error) {
+	slog.Debug("using grpc exporter",
+		slog.String("endpoint", tp.grpc.endpoint),
+	)
+	conn, err := grpc.NewClient(
+		tp.grpc.endpoint,
+		grpc.WithTransportCredentials(tp.grpc.credentials),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create grpc connection to collector: %w", err)
+	}
+	exporter, err := otlptracegrpc.New(tp.ctx, otlptracegrpc.WithGRPCConn(conn))
+	return exporter, err
 }
 
 func (tp *TracerProvider) Run() error {
@@ -118,6 +168,7 @@ func (tp *TracerProvider) Name() string {
 
 type Opt func(*TracerProvider) error
 
+// WithSamplePercentage sets the percentage of spans to sample. Allowed values are 0-100.
 func WithSamplePercentage(percentage int) Opt {
 	return func(tp *TracerProvider) error {
 		if percentage > 100 || percentage < 0 {
@@ -128,15 +179,39 @@ func WithSamplePercentage(percentage int) Opt {
 	}
 }
 
+// WithCollector is deprecated. Use WithGRPCExporter instead.
 func WithCollector(host string, port int, credentials credentials.TransportCredentials) Opt {
+	slog.Warn("WithCollector is deprecated, use WithGRPCExporter instead")
+	return WithGRPCExporter(fmt.Sprintf("%s:%d", host, port), credentials)
+}
+
+// WithGRPCExporter sets gRPC collector endpoint for trace exporter.
+// Endpoint is "host:port" of the collector and you can set transport credentials to "insecure.NewCredentials()"
+// if secure connection is not required.
+func WithGRPCExporter(endpoint string, credentials credentials.TransportCredentials) Opt {
 	return func(tp *TracerProvider) error {
-		tp.collectorHost = host
-		tp.collectorPort = port
-		tp.credentials = credentials
+		tp.grpc.endpoint = endpoint
+		tp.grpc.credentials = credentials
 		return nil
 	}
 }
 
+// WithHTTPExporter sets HTTP exporter endpoint for trace exporter with an authorization token.
+// Endpoint is "host:port" of to the collector and you can set token as "ApiKey <token>" or "Bearer <token>".
+// Set token to empty if not needed. Insecure disables TLS.
+func WithHTTPExporter(endpoint string, token string, insecure bool) Opt {
+	return func(tp *TracerProvider) error {
+		if token != "" && !(strings.HasPrefix(strings.ToLower(token), "apikey ") || strings.HasPrefix(strings.ToLower(token), "bearer ")) {
+			return ErrInvalidToken
+		}
+		tp.http.endpoint = endpoint
+		tp.http.token = token
+		tp.http.insecure = insecure
+		return nil
+	}
+}
+
+// WithContext sets the context for the tracer provider.
 func WithContext(ctx context.Context) Opt {
 	return func(tp *TracerProvider) error {
 		tp.ctx = ctx
@@ -144,6 +219,7 @@ func WithContext(ctx context.Context) Opt {
 	}
 }
 
+// WithServiceName sets the service name attribute for the tracer provider.
 func WithServiceName(serviceName string) Opt {
 	return func(tp *TracerProvider) error {
 		tp.serviceName = semconv.ServiceNameKey.String(serviceName)
@@ -151,6 +227,18 @@ func WithServiceName(serviceName string) Opt {
 	}
 }
 
+// WithEnvironment sets the deployment environment name attribute for the tracer provider.
+func WithEnvironment(environment string) Opt {
+	return func(tp *TracerProvider) error {
+		if environment != "" {
+			tp.environment = semconv.DeploymentEnvironment(environment)
+		}
+		return nil
+	}
+}
+
+// WithProcessor sets the span processor for the tracer provider. Allowed values are "batch" and "simple",
+// but "simple" should not be used in production.
 func WithProcessor(processorName string) Opt {
 	return func(tp *TracerProvider) error {
 		switch processorName {

--- a/v2/service/module/tracerprovider/tracerprovider_test.go
+++ b/v2/service/module/tracerprovider/tracerprovider_test.go
@@ -11,12 +11,30 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func TestTracerProvider(t *testing.T) {
+func TestTracerProviderGRPC(t *testing.T) {
 	tp := tracerprovider.New(
 		tracerprovider.WithSamplePercentage(42),
-		tracerprovider.WithCollector("localhost", 4317, insecure.NewCredentials()),
+		tracerprovider.WithGRPCExporter("localhost:4317", insecure.NewCredentials()),
 		tracerprovider.WithContext(context.Background()),
 		tracerprovider.WithServiceName("test"),
+		tracerprovider.WithEnvironment("development"),
+		tracerprovider.WithProcessor(tracerprovider.ProcessorBatch),
+	)
+	require.NoError(t, tp.Init())
+	wg := &multierror.Group{}
+	wg.Go(tp.Run)
+	require.NoError(t, tp.Stop())
+	require.NoError(t, wg.Wait().ErrorOrNil())
+	require.Equal(t, "otel.TracerProvider", tp.Name())
+}
+
+func TestTracerProviderHTTP(t *testing.T) {
+	tp := tracerprovider.New(
+		tracerprovider.WithSamplePercentage(42),
+		tracerprovider.WithHTTPExporter("localhost:4318", "ApiKey verysecret", true),
+		tracerprovider.WithContext(context.Background()),
+		tracerprovider.WithServiceName("test"),
+		tracerprovider.WithEnvironment("development"),
 		tracerprovider.WithProcessor(tracerprovider.ProcessorBatch),
 	)
 	require.NoError(t, tp.Init())
@@ -54,6 +72,11 @@ func TestTracerProviderInitErrors(t *testing.T) {
 			name:        "ErrInvalidProcessor",
 			tp:          tracerprovider.New(tracerprovider.WithProcessor("foo")),
 			expectedErr: tracerprovider.ErrInvalidProcessor,
+		},
+		{
+			name:        "ErrInvalidToken",
+			tp:          tracerprovider.New(tracerprovider.WithHTTPExporter("localhost:4318", "token", true)),
+			expectedErr: tracerprovider.ErrInvalidToken,
 		},
 	}
 

--- a/v2/service/module/tracerprovider/tracerprovider_test.go
+++ b/v2/service/module/tracerprovider/tracerprovider_test.go
@@ -81,7 +81,6 @@ func TestTracerProviderInitErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.tp.Init()
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/v2/service/module/watcher/watcher_test.go
+++ b/v2/service/module/watcher/watcher_test.go
@@ -142,7 +142,6 @@ func TestWatcherInitErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.watcher.Init()
 			require.ErrorIs(t, err, tc.expectedErr)

--- a/v2/service/service.go
+++ b/v2/service/service.go
@@ -73,7 +73,6 @@ type runner struct {
 func (r *runner) run() error {
 	slog.Info("initializing modules")
 	for _, mod := range r.modules {
-		mod := mod
 		slog.Info("module initializing", slog.String("name", mod.Name()))
 		err := catchPanic(mod.Init)
 		if err != nil {
@@ -89,7 +88,6 @@ func (r *runner) run() error {
 
 	wg := &multierror.Group{}
 	for _, mod := range r.modules {
-		mod := mod
 		wg.Go(func() error {
 			defer func() {
 				slog.Info("module run exited", slog.String("name", mod.Name()))

--- a/v2/service/service_test.go
+++ b/v2/service/service_test.go
@@ -65,7 +65,6 @@ func TestRun(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			stopMod, stop := StopMod()
 			tc.mods = append(tc.mods, stopMod)


### PR DESCRIPTION
Works with Elastic: `tracerprovider.WithHTTPExporter("apmserver:443", "Bearer foobar",  false)`