### PR TITLE
Define integer format

### DIFF
--- a/v2/httputil/util.go
+++ b/v2/httputil/util.go
@@ -28,7 +28,7 @@ func (e ErrorResponse) Error() string {
 
 // ErrorResponse provides HTTP error response.
 type ErrorResponse struct {
-	Code      uint              `json:"code,omitempty" example:"400"`
+	Code      int64             `json:"code,omitempty" format:"int64" example:"400"`
 	Message   string            `json:"message" example:"Bad request"`
 	ErrorType string            `json:"error_type,omitempty" example:"invalid_scope"`
 	Params    map[string]string `json:"params,omitempty"`


### PR DESCRIPTION
Just to comply with the `MUST define a format for number and integer types` API lint rule.

https://spec.openapis.org/oas/v3.1.1.html#data-type-format