### PR TITLE
Add Binhandler opts for stdout/stderr and run environment

### DIFF
--- a/v2/integrationtest/bin_handler.go
+++ b/v2/integrationtest/bin_handler.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -25,6 +26,8 @@ type BinHandler struct {
 	buildEnv  []string
 	runArgs   []string
 	runEnv    []string
+	runStdout io.Writer
+	runStderr io.Writer
 	coverDir  string
 	opts      []BinOpt
 }
@@ -34,6 +37,8 @@ func NewBinHandler(opts ...BinOpt) *BinHandler {
 		base:      ".",
 		opts:      opts,
 		buildOnce: &sync.Once{},
+		runStdout: os.Stdout,
+		runStderr: os.Stderr,
 	}
 }
 
@@ -102,8 +107,8 @@ func (bh *BinHandler) initRunCommand() error {
 
 	bh.runEnv = append(bh.runEnv, "GOCOVERDIR="+bh.coverDir)
 	bh.runCmd = exec.Command(bh.bin, bh.runArgs...) //nolint:gosec
-	bh.runCmd.Stdout = os.Stdout
-	bh.runCmd.Stderr = os.Stderr
+	bh.runCmd.Stdout = bh.runStdout
+	bh.runCmd.Stderr = bh.runStderr
 	bh.runCmd.Env = append(bh.runCmd.Environ(), bh.runEnv...)
 	bh.runCmd.Dir = bh.base
 

--- a/v2/integrationtest/bin_opts.go
+++ b/v2/integrationtest/bin_opts.go
@@ -110,3 +110,11 @@ func BinOptRunStderr(stderr io.Writer) BinOpt {
 		return nil
 	}
 }
+
+// BinOptRunInheritEnv sets boolean to determine whether test binary inherits env from caller.
+func BinOptRunInheritEnv(inherit bool) BinOpt {
+	return func(bh *BinHandler) error {
+		bh.runInheritEnv = inherit
+		return nil
+	}
+}

--- a/v2/integrationtest/bin_opts.go
+++ b/v2/integrationtest/bin_opts.go
@@ -2,6 +2,7 @@ package integrationtest
 
 import (
 	"fmt"
+	"io"
 	"path/filepath"
 )
 
@@ -90,6 +91,22 @@ func BinOptBuildEnv(env ...string) BinOpt {
 func BinOptCoverDir(coverDir string) BinOpt {
 	return func(bh *BinHandler) error {
 		bh.coverDir = coverDir
+		return nil
+	}
+}
+
+// BinOptRunStdout sets stdout for test binary.
+func BinOptRunStdout(stdout io.Writer) BinOpt {
+	return func(bh *BinHandler) error {
+		bh.runStdout = stdout
+		return nil
+	}
+}
+
+// BinOptRunStderr sets stderr for test binary.
+func BinOptRunStderr(stderr io.Writer) BinOpt {
+	return func(bh *BinHandler) error {
+		bh.runStderr = stderr
 		return nil
 	}
 }

--- a/v2/integrationtest/it_runner_test.go
+++ b/v2/integrationtest/it_runner_test.go
@@ -61,6 +61,9 @@ func TestOptBinHandler(t *testing.T) {
 	itr := it.NewIntegrationTestRunner(
 		it.OptBase("./testdata"),
 		it.OptBinHandler(bh),
+		it.OptRunStdout(os.Stdout),
+		it.OptRunStderr(os.Stderr),
+		it.OptRunInheritEnv(true),
 		it.OptRunEnv("ITR_TEST_ADDR=:8180"),
 		it.OptWaitHTTPReady("http://127.0.0.1:8180/ready", time.Second*10),
 		it.OptCompose("docker-compose.yaml",

--- a/v2/integrationtest/opts.go
+++ b/v2/integrationtest/opts.go
@@ -103,6 +103,13 @@ func OptRunStderr(stderr io.Writer) Opt {
 	}
 }
 
+// OptRunInheritEnv sets boolean to determine whether test binary inherits env from caller.
+func OptRunInheritEnv(inherit bool) Opt {
+	return func(itr *IntegrationTestRunner) error {
+		return BinOptRunInheritEnv(inherit)(itr.binHandler)
+	}
+}
+
 // OptTestMain allows wrapping testing.M into IntegrationTestRunner.
 // Example TestMain:
 //

--- a/v2/integrationtest/opts.go
+++ b/v2/integrationtest/opts.go
@@ -3,6 +3,7 @@ package integrationtest
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"path"
 	"path/filepath"
@@ -85,6 +86,20 @@ func OptBuildEnv(env ...string) Opt {
 func OptCoverDir(coverDir string) Opt {
 	return func(itr *IntegrationTestRunner) error {
 		return BinOptCoverDir(coverDir)(itr.binHandler)
+	}
+}
+
+// OptRunStdout sets stdout for test binary.
+func OptRunStdout(stdout io.Writer) Opt {
+	return func(itr *IntegrationTestRunner) error {
+		return BinOptRunStdout(stdout)(itr.binHandler)
+	}
+}
+
+// OptRunStderr sets stderr for test binary.
+func OptRunStderr(stderr io.Writer) Opt {
+	return func(itr *IntegrationTestRunner) error {
+		return BinOptRunStderr(stderr)(itr.binHandler)
 	}
 }
 


### PR DESCRIPTION
- Make stdout/stderr of the test binary configurable to allow capturing output in tests.
- Make test binary's run environment inheritance optional to enable more deterministic tests.