### PR TITLE
Add ctxlog package for context-based logger propagation

### DIFF
--- a/v2/ctxlog/ctxlog.go
+++ b/v2/ctxlog/ctxlog.go
@@ -1,0 +1,196 @@
+// Package ctxlog provides context-based logger propagation.
+//
+// It is a thin convenience layer over log/slog: a *slog.Logger is carried in
+// the context, and the package-level logging functions retrieve it (falling
+// back to slog.Default()) and emit records with the calling code's source
+// location. This lets applications thread a request-scoped logger through
+// ctx instead of re-implementing the same "stash logger / pull logger"
+// boilerplate everywhere.
+//
+// ctxlog does not itself add trace_id/span_id attributes. It only forwards
+// the context into the handler. Trace enrichment happens when the stored (or
+// default) logger's handler reads the span context from ctx — for example the
+// handler installed by github.com/elisasre/go-common/v2/log.NewDefaultEnvLogger,
+// which is also why FromContext falls back to slog.Default().
+//
+// ctxlog is a leaf API: source location is captured for the direct caller.
+// Wrapping these functions makes every record point at the wrapper; build a
+// custom facade on slog.Handler instead.
+//
+// All functions are safe for concurrent use and tolerate a nil context
+// (treated as context.Background()), so a logging call never panics on a
+// missing context.
+//
+// # Call-site safety
+//
+// The ...any family (Debug, Info, Warn, Error, Log, With) is ergonomic but
+// statically unchecked: a mismatched pair yields a !BADKEY attribute at run
+// time, not a compile error — the same trade-off as slog.Info vs LogAttrs.
+// sloglint cannot see ctxlog calls and no linter can check this family
+// correctly (ctxlog.Info(ctx, "m", slog.String("k", v)) is valid but would
+// be rejected). Where correctness must be guaranteed use LogAttrs or
+// WithAttrs: they take ...slog.Attr, so the compiler rejects a bad call.
+//
+// # Operational notes
+//
+// Call With, WithAttrs and WithGroup once per scope, not per loop iteration:
+// each adds a context node and wraps the handler (O(n) in a hot loop).
+//
+// Handler errors are dropped, as in slog.Logger; ctxlog gives no delivery
+// guarantee. Enforce delivery at the handler/transport layer if required.
+package ctxlog
+
+import (
+	"context"
+	"log/slog"
+	"runtime"
+	"time"
+)
+
+type contextKey struct{}
+
+// WithLogger stores a *slog.Logger in the context.
+// A nil ctx is treated as context.Background().
+func WithLogger(ctx context.Context, l *slog.Logger) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, contextKey{}, l)
+}
+
+// FromContext retrieves the *slog.Logger from the context.
+// Falls back to slog.Default() if ctx is nil, no logger is stored, or a nil
+// logger was stored via WithLogger(ctx, nil).
+func FromContext(ctx context.Context) *slog.Logger {
+	if ctx != nil {
+		if l, ok := ctx.Value(contextKey{}).(*slog.Logger); ok && l != nil {
+			return l
+		}
+	}
+	return slog.Default()
+}
+
+// logCtx builds the record itself so the captured source location points at
+// the caller of the exported wrapper rather than at this file. It must be
+// called directly by an exported logging function: the runtime.Callers skip
+// of 3 is calibrated for the chain
+//
+//	caller -> ctxlog.<Wrapper> -> logCtx -> runtime.Callers
+//
+// skipping [runtime.Callers, logCtx, <Wrapper>]. Do not introduce an
+// intermediate frame between an exported function and logCtx.
+func logCtx(ctx context.Context, level slog.Level, msg string, args ...any) { //nolint:contextcheck // Background is substituted only for a nil ctx (defensive guard)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	l := FromContext(ctx)
+	if !l.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, logCtx, exported wrapper]
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.Add(args...)
+	_ = l.Handler().Handle(ctx, r)
+}
+
+// logAttrsCtx is logCtx for the typed-Attr path, kept separate so LogAttrs
+// avoids boxing attributes into any. The same skip-3 calibration applies.
+func logAttrsCtx(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) { //nolint:contextcheck // Background is substituted only for a nil ctx (defensive guard)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	l := FromContext(ctx)
+	if !l.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip [Callers, logAttrsCtx, exported wrapper]
+	r := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	r.AddAttrs(attrs...)
+	_ = l.Handler().Handle(ctx, r)
+}
+
+// Debug logs at LevelDebug using the logger from ctx.
+func Debug(ctx context.Context, msg string, args ...any) {
+	logCtx(ctx, slog.LevelDebug, msg, args...)
+}
+
+// Info logs at LevelInfo using the logger from ctx.
+func Info(ctx context.Context, msg string, args ...any) {
+	logCtx(ctx, slog.LevelInfo, msg, args...)
+}
+
+// Warn logs at LevelWarn using the logger from ctx.
+func Warn(ctx context.Context, msg string, args ...any) {
+	logCtx(ctx, slog.LevelWarn, msg, args...)
+}
+
+// Error logs at LevelError using the logger from ctx.
+func Error(ctx context.Context, msg string, args ...any) {
+	logCtx(ctx, slog.LevelError, msg, args...)
+}
+
+// Log logs at a caller-supplied level using the logger from ctx.
+func Log(ctx context.Context, level slog.Level, msg string, args ...any) {
+	logCtx(ctx, level, msg, args...)
+}
+
+// LogAttrs logs at the given level using the logger from ctx.
+func LogAttrs(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
+	logAttrsCtx(ctx, level, msg, attrs...)
+}
+
+// Enabled reports whether a record at the given level would be emitted by the
+// logger in ctx. Use it to guard construction of expensive log arguments.
+func Enabled(ctx context.Context, level slog.Level) bool { //nolint:contextcheck // Background is substituted only for a nil ctx (defensive guard)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return FromContext(ctx).Enabled(ctx, level)
+}
+
+// With returns a copy of ctx whose logger has the given attributes added.
+// It is the context-scoped analog of slog.Logger.With and derives from
+// FromContext(ctx). With no args it returns ctx unchanged.
+//
+// The returned context must be used. Like context.WithValue, discarding the
+// result is a silent no-op — the attributes are lost, not added in place.
+//
+// The logger is snapshotted at call time: if none is stored in ctx the
+// current slog.Default() is captured, so call this only after the
+// application has installed its real default logger.
+func With(ctx context.Context, args ...any) context.Context {
+	if len(args) == 0 {
+		return ctx
+	}
+	return WithLogger(ctx, FromContext(ctx).With(args...))
+}
+
+// WithAttrs returns a copy of ctx whose logger has the given typed attributes
+// added. It is the compile-checked analog of With (no !BADKEY risk) and the
+// context-binding counterpart of LogAttrs. With no attrs it returns ctx
+// unchanged.
+//
+// The returned context must be used; discarding the result is a silent no-op.
+// The same snapshot semantics as With apply.
+func WithAttrs(ctx context.Context, attrs ...slog.Attr) context.Context {
+	if len(attrs) == 0 {
+		return ctx
+	}
+	return WithLogger(ctx, slog.New(FromContext(ctx).Handler().WithAttrs(attrs)))
+}
+
+// WithGroup returns a copy of ctx whose logger starts a group with the given
+// name. It is the context-scoped analog of slog.Logger.WithGroup and derives
+// from FromContext(ctx). An empty name returns ctx unchanged, mirroring
+// slog.Logger.WithGroup.
+//
+// The returned context must be used; discarding the result is a silent no-op.
+// The same snapshot semantics as With apply.
+func WithGroup(ctx context.Context, name string) context.Context {
+	if name == "" {
+		return ctx
+	}
+	return WithLogger(ctx, FromContext(ctx).WithGroup(name))
+}

--- a/v2/ctxlog/ctxlog_test.go
+++ b/v2/ctxlog/ctxlog_test.go
@@ -1,0 +1,348 @@
+package ctxlog_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/elisasre/go-common/v2/ctxlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func parseJSONLog(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	return m
+}
+
+func TestFromContext_Default(t *testing.T) {
+	ctx := context.Background()
+	logger := ctxlog.FromContext(ctx)
+	assert.Equal(t, slog.Default(), logger)
+}
+
+func TestFromContext_WithLogger(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	got := ctxlog.FromContext(ctx)
+	assert.Equal(t, logger, got)
+}
+
+func TestDebug(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Debug(ctx, "debug msg", "key", "val")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "DEBUG", m["level"])
+	assert.Equal(t, "debug msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+func TestInfo(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Info(ctx, "info msg", "key", "val")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "INFO", m["level"])
+	assert.Equal(t, "info msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+func TestWarn(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Warn(ctx, "warn msg", "key", "val")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "WARN", m["level"])
+	assert.Equal(t, "warn msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+func TestError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Error(ctx, "error msg", "key", "val")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "ERROR", m["level"])
+	assert.Equal(t, "error msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+func TestLog(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Log(ctx, slog.LevelWarn, "log msg", "key", "val")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "WARN", m["level"])
+	assert.Equal(t, "log msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+func TestLogAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.LogAttrs(ctx, slog.LevelWarn, "attrs msg", slog.String("key", "val"))
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "WARN", m["level"])
+	assert.Equal(t, "attrs msg", m["msg"])
+	assert.Equal(t, "val", m["key"])
+}
+
+// TestSource_PointsAtCallSite is the regression gate for the PC-skip bug:
+// the source location must point at the calling file, never at ctxlog.go.
+// Every exported logging function is covered because each is an independent
+// entry point into the skip-3 chain — a refactor that adds a frame to any one
+// of them must fail here rather than ship a silently-wrong source location.
+// It deliberately asserts only file and function (not an exact line) so that
+// reformatting or editing this test does not produce confusing failures.
+func TestSource_PointsAtCallSite(t *testing.T) {
+	calls := []struct {
+		name string
+		emit func(ctx context.Context)
+	}{
+		{"Debug", func(ctx context.Context) { ctxlog.Debug(ctx, "m") }},
+		{"Info", func(ctx context.Context) { ctxlog.Info(ctx, "m") }},
+		{"Warn", func(ctx context.Context) { ctxlog.Warn(ctx, "m") }},
+		{"Error", func(ctx context.Context) { ctxlog.Error(ctx, "m") }},
+		{"Log", func(ctx context.Context) { ctxlog.Log(ctx, slog.LevelInfo, "m") }},
+		{"LogAttrs", func(ctx context.Context) { ctxlog.LogAttrs(ctx, slog.LevelInfo, "m") }},
+	}
+
+	for _, c := range calls {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				AddSource: true,
+				Level:     slog.LevelDebug, // ensure Debug emits too
+			}))
+			ctx := ctxlog.WithLogger(context.Background(), logger)
+
+			c.emit(ctx)
+
+			m := parseJSONLog(t, &buf)
+			src, ok := m["source"].(map[string]any)
+			require.True(t, ok, "source attribute missing: %v", m)
+
+			file, _ := src["file"].(string)
+			assert.Equal(t, "ctxlog_test.go", filepath.Base(file),
+				"source.file must be the caller's file, not the ctxlog package")
+
+			fn, _ := src["function"].(string)
+			assert.Contains(t, fn, "TestSource_PointsAtCallSite",
+				"source.function should be the caller, got %q", fn)
+		})
+	}
+}
+
+func TestWithLogger_TypedNil(t *testing.T) {
+	ctx := ctxlog.WithLogger(context.Background(), nil)
+
+	assert.Equal(t, slog.Default(), ctxlog.FromContext(ctx))
+	assert.NotPanics(t, func() {
+		ctxlog.Info(ctx, "no panic with nil-stored logger")
+	})
+}
+
+func TestEnabledShortCircuit(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Debug(ctx, "should be dropped")
+
+	assert.Zero(t, buf.Len(), "debug below handler level must not emit")
+}
+
+// TestLogAttrs_Disabled covers logAttrsCtx's Enabled short-circuit, the
+// typed-Attr counterpart of TestEnabledShortCircuit.
+func TestLogAttrs_Disabled(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.LogAttrs(ctx, slog.LevelInfo, "should be dropped", slog.String("k", "v"))
+
+	assert.Zero(t, buf.Len(), "LogAttrs below handler level must not emit")
+}
+
+func TestWith(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	assert.Equal(t, ctx, ctxlog.With(ctx), "With with no args must return ctx unchanged")
+
+	ctx = ctxlog.With(ctx, "rid", "abc")
+	ctx = ctxlog.With(ctx, "k2", "v2")
+	ctxlog.Info(ctx, "m")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "abc", m["rid"], "chained With must retain earlier attrs")
+	assert.Equal(t, "v2", m["k2"])
+}
+
+func TestWith_DefaultFallback(t *testing.T) {
+	assert.NotPanics(t, func() {
+		ctx := ctxlog.With(context.Background(), "k", "v")
+		ctxlog.Info(ctx, "m")
+	})
+}
+
+func TestWithAttrs(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	assert.Equal(t, ctx, ctxlog.WithAttrs(ctx), "WithAttrs with no attrs must return ctx unchanged")
+
+	ctx = ctxlog.WithAttrs(ctx, slog.String("rid", "abc"))
+	ctx = ctxlog.WithAttrs(ctx, slog.Int("attempt", 2))
+	ctxlog.Info(ctx, "m")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "abc", m["rid"], "chained WithAttrs must retain earlier attrs")
+	assert.EqualValues(t, 2, m["attempt"])
+}
+
+func TestWithGroup(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	gctx := ctxlog.WithGroup(ctx, "g")
+	ctxlog.Info(gctx, "m", "k", "v")
+
+	m := parseJSONLog(t, &buf)
+	group, ok := m["g"].(map[string]any)
+	require.True(t, ok, "expected nested group %q in %v", "g", m)
+	assert.Equal(t, "v", group["k"])
+}
+
+func TestWithGroup_EmptyName(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	assert.Equal(t, ctx, ctxlog.WithGroup(ctx, ""),
+		"WithGroup with empty name must return ctx unchanged")
+
+	ctx = ctxlog.WithGroup(ctx, "")
+	ctxlog.Info(ctx, "m", "k", "v")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, "v", m["k"], "empty group name keeps attrs top-level")
+}
+
+func TestNilContext(t *testing.T) {
+	var nilCtx context.Context // typed nil: the case under test
+
+	assert.Equal(t, slog.Default(), ctxlog.FromContext(nilCtx))
+	assert.NotPanics(t, func() {
+		ctxlog.Info(nilCtx, "no panic on nil ctx")
+		ctxlog.LogAttrs(nilCtx, slog.LevelInfo, "no panic", slog.Int("n", 1))
+		ctx := ctxlog.WithLogger(nilCtx, slog.Default())
+		ctxlog.With(ctx, "k", "v")
+		ctxlog.WithGroup(ctx, "g")
+		_ = ctxlog.Enabled(nilCtx, slog.LevelInfo)
+	})
+}
+
+func TestEnabled(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn})) //nolint:sloglint // real level-gating handler required; slog.DiscardHandler.Enabled is always false
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	assert.False(t, ctxlog.Enabled(ctx, slog.LevelInfo))
+	assert.True(t, ctxlog.Enabled(ctx, slog.LevelError))
+}
+
+// TestDisabledPathZeroAlloc guards the Enabled short-circuit: a below-level
+// call with no args must not allocate, so logging stays cheap on hot paths.
+func TestDisabledPathZeroAlloc(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn})) //nolint:sloglint // real level-gating handler required; slog.DiscardHandler.Enabled is always false
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	avg := testing.AllocsPerRun(100, func() {
+		ctxlog.Debug(ctx, "skipped")
+	})
+	assert.Zero(t, avg, "disabled-level fast path must not allocate")
+}
+
+// countingWriter counts Write calls. slog's JSON handler emits one Write per
+// record, so the count equals the number of records written.
+type countingWriter struct{ n atomic.Int64 }
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.n.Add(1)
+	return len(p), nil
+}
+
+// TestConcurrentUse backs the "safe for concurrent use" doc claim: many
+// goroutines derive their own context with With and log on it simultaneously.
+// Run with -race; every record must be emitted exactly once.
+func TestConcurrentUse(t *testing.T) {
+	w := &countingWriter{}
+	logger := slog.New(slog.NewJSONHandler(w, nil))
+	base := ctxlog.WithLogger(context.Background(), logger)
+
+	const goroutines, perG = 50, 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func() {
+			defer wg.Done()
+			gctx := ctxlog.With(base, "goroutine", g)
+			for i := range perG {
+				ctxlog.Info(gctx, "concurrent", "i", i)
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(goroutines*perG), w.n.Load())
+}
+
+func BenchmarkInfo(b *testing.B) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil)) //nolint:sloglint // benchmark must exercise the real encode path, not a no-op handler
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+	b.ReportAllocs()
+	for b.Loop() {
+		ctxlog.Info(ctx, "msg", "key", "val")
+	}
+}
+
+func BenchmarkInfoDisabled(b *testing.B) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelWarn})) //nolint:sloglint // real level-gating handler required; slog.DiscardHandler.Enabled is always false
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+	b.ReportAllocs()
+	for b.Loop() {
+		ctxlog.Debug(ctx, "skipped")
+	}
+}

--- a/v2/ctxlog/ctxlog_trace_test.go
+++ b/v2/ctxlog/ctxlog_trace_test.go
@@ -1,0 +1,54 @@
+package ctxlog_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/elisasre/go-common/v2/ctxlog"
+	"github.com/elisasre/go-common/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// TestTraceEnrichment locks in the documented dependency: ctxlog does not add
+// trace fields itself, but when the logger is the one installed by
+// log.NewDefaultEnvLogger (which wraps the handler in spanContextLogHandler),
+// trace_id/span_id/trace_sampled flow through because ctxlog forwards ctx
+// into Handler().Handle(ctx, r).
+func TestTraceEnrichment(t *testing.T) {
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	// NewDefaultEnvLogger reads these; pin them so the test asserts ctxlog
+	// behavior, not the ambient shell/CI environment.
+	t.Setenv("LOG_FORMAT", "JSON")
+	t.Setenv("LOG_LEVEL", "INFO")
+
+	var buf bytes.Buffer
+	logger := log.NewDefaultEnvLogger(log.WithOutput(&buf))
+
+	traceID, err := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("0102030405060708")
+	require.NoError(t, err)
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+	})
+	require.True(t, sc.IsValid())
+
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+	ctx = ctxlog.WithLogger(ctx, logger)
+
+	ctxlog.Info(ctx, "traced message")
+
+	m := parseJSONLog(t, &buf)
+	assert.Equal(t, traceID.String(), m[log.TraceID])
+	assert.Equal(t, spanID.String(), m[log.SpanID])
+	assert.Equal(t, true, m[log.TraceSampled])
+}

--- a/v2/ctxlog/example_test.go
+++ b/v2/ctxlog/example_test.go
@@ -1,0 +1,51 @@
+package ctxlog_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/elisasre/go-common/v2/ctxlog"
+)
+
+// dropTime removes the volatile top-level time attribute so example output is
+// deterministic.
+func dropTime(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) == 0 && a.Key == slog.TimeKey {
+		return slog.Attr{}
+	}
+	return a
+}
+
+func ExampleInfo() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{ReplaceAttr: dropTime}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	ctxlog.Info(ctx, "user logged in", "user", "alice")
+	// Output: level=INFO msg="user logged in" user=alice
+}
+
+func ExampleWith() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{ReplaceAttr: dropTime}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	// Bind request-scoped attributes once; every later call carries them.
+	ctx = ctxlog.With(ctx, "request_id", "r-123")
+	ctxlog.Info(ctx, "handling request")
+	ctxlog.Warn(ctx, "slow response")
+	// Output:
+	// level=INFO msg="handling request" request_id=r-123
+	// level=WARN msg="slow response" request_id=r-123
+}
+
+func ExampleLogAttrs() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{ReplaceAttr: dropTime}))
+	ctx := ctxlog.WithLogger(context.Background(), logger)
+
+	// LogAttrs takes typed slog.Attr values: compile-checked, no !BADKEY risk.
+	ctxlog.LogAttrs(ctx, slog.LevelError, "payment failed",
+		slog.String("order", "o-9"),
+		slog.Int("attempt", 3),
+	)
+	// Output: level=ERROR msg="payment failed" order=o-9 attempt=3
+}


### PR DESCRIPTION
Adds `v2/ctxlog`: a thin `log/slog` convenience layer that carries a `*slog.Logger` in `context.Context`, so services stop re-implementing stash/pull-logger boilerplate. New package, no existing callers, no other changes.

- Source location points at the real caller, not the wrapper.
- Adds no trace attributes itself; `trace_id`/`span_id` flow through when paired with `v2/log`'s handler.
- nil-context safe; safe for concurrent use.
- `Info`/`With`-family ergonomic; `LogAttrs`/`WithAttrs` typed and compile-checked — same trade-off as stdlib `slog.Info` vs `slog.LogAttrs`.
