### PR TITLE
Fix nil-pointer panic in TestServerShutdownTimeout

### DIFF
--- a/v2/service/module/httpserver/server_test.go
+++ b/v2/service/module/httpserver/server_test.go
@@ -166,7 +166,9 @@ func TestServerShutdownTimeout(t *testing.T) {
 
 	go func() {
 		resp, err := http.Get(url) //nolint:gosec
-		assert.NoError(t, err)
+		if err != nil {
+			return // request interrupted by the forced shutdown — expected here
+		}
 		io.Copy(io.Discard, resp.Body) //nolint: errcheck
 	}()
 


### PR DESCRIPTION
Probe goroutine dereferenced `resp.Body` after the shutdown timeout force-closed the request (`resp == nil`), panicking the package. Guard the error instead of asserting `NoError` (the request is expected to be interrupted here). Pre-existing test bug.