### PR TITLE
Set TLS MinVersion in TestHTTPS instead of suppressing gosec G402

### DIFF
--- a/v2/service/module/httpserver/server_test.go
+++ b/v2/service/module/httpserver/server_test.go
@@ -39,7 +39,7 @@ func TestHTTPS(t *testing.T) {
 	srv := httpserver.New(httpserver.WithServer(&http.Server{
 		Addr:              "127.0.0.1:0",
 		ReadHeaderTimeout: time.Second,
-		TLSConfig:         &tls.Config{}, //nolint:gosec
+		TLSConfig:         &tls.Config{MinVersion: tls.VersionTLS12},
 	}))
 	err := srv.Init()
 	require.NoError(t, err)


### PR DESCRIPTION
`TestHTTPS` used `&tls.Config{}` with a `//nolint:gosec` to silence gosec G402 (TLS MinVersion too low). Set `MinVersion: tls.VersionTLS12` so the config is actually secure and the suppression is no longer needed.